### PR TITLE
Fixed infinite recursive call for rspec check

### DIFF
--- a/lib/flexmock/rspec.rb
+++ b/lib/flexmock/rspec.rb
@@ -27,7 +27,7 @@ class FlexMock
     end
 
     def check(msg, &block)
-      check(msg, &block)
+      make_assertion(msg, &block)
     end
 
     class AssertionFailedError < StandardError; end


### PR DESCRIPTION
While upgrading the flexmock 2.0.2 from the latest 1.x version, we were getting stack too deep errors when calling mocked methods.

I'm not too familiar with the new "check" methods, but it appears to be an obvious infinite recursive call. I changed the check method to mimic the other test framework check calls.