### PR TITLE
Make rspec make_assertion compatible with new code

### DIFF
--- a/lib/flexmock/rspec.rb
+++ b/lib/flexmock/rspec.rb
@@ -21,7 +21,7 @@ class FlexMock
   end
 
   class RSpecFrameworkAdapter
-    def make_assertion(msg, &block)
+    def make_assertion(msg, backtrace = caller, &block)
       msg = msg.call if msg.is_a?(Proc)
       SpecModule::Expectations.fail_with(msg) unless yield
     end


### PR DESCRIPTION
The make_assertion call in FlexMock::Expectation provides a second
argument, @location, to the make_assertion call. As a result this is no
longer compatible with the FlexMock RSpec integration. This leads to a
test failure in the rspec integration tests.

It is not clear to me if the backtrace can and should be passed to
rspec, so I have opted to only provide a placeholder argument for it.

The rspec tests can be run with "rspec test/rspec_integration"