### PR TITLE
Make test-unit make_assertion compatible with new code

### DIFF
--- a/lib/flexmock/test_unit_integration.rb
+++ b/lib/flexmock/test_unit_integration.rb
@@ -51,7 +51,7 @@ class FlexMock
         @assertions = 0
     end
 
-    def make_assertion(msg, &block)
+    def make_assertion(msg, backtrace = caller, &block)
       unless yield
         msg = msg.call if msg.is_a?(Proc)
         assert(false, msg)


### PR DESCRIPTION
Similar to https://github.com/doudou/flexmock/pull/2 but for test-unit.

Currently, I got following error when test failed:

```
Error: test_parser_error_warning(ParserFilterTest): ArgumentError: wrong number of arguments (given 2, expected 1)
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/test_unit_integration.rb:54:in `make_assertion'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/expectation.rb:168:in `rescue in flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/expectation.rb:164:in `flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/expectation_director.rb:70:in `block in flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/expectation_director.rb:69:in `each'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/expectation_director.rb:69:in `flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/core.rb:113:in `block (2 levels) in flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/core.rb:112:in `each'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/core.rb:112:in `block in flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/core.rb:283:in `flexmock_wrap'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/core.rb:111:in `flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/mock_container.rb:41:in `block in flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/mock_container.rb:40:in `each'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/mock_container.rb:40:in `flexmock_verify'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/mock_container.rb:33:in `flexmock_teardown'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/test_unit_testcase_extensions.rb:25:in `teardown'
/Users/repeatedly/dev/fluentd/fluentd/vendor/bundle/ruby/2.3.0/gems/flexmock-2.3.1/lib/flexmock/test_unit_integration.rb:37:in `teardown'
/Users/repeatedly/dev/fluentd/fluentd/test/plugin/test_filter_parser.rb:18:in `teardown'
```