### PR TITLE
Keyword argument support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Unit Tests
+
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version:
+          - "3.2"
+          - "3.1"
+          - "3.0"
+          - "2.7"
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake test

--- a/lib/flexmock/argument_matchers.rb
+++ b/lib/flexmock/argument_matchers.rb
@@ -62,6 +62,9 @@ class FlexMock
     def ===(target)
       @hash.all? { |k, v| target[k] == v }
     end
+    def empty?
+      @hash.empty?
+    end
     def inspect
       "hsh(#{@hash.inspect})"
     end

--- a/lib/flexmock/argument_matching.rb
+++ b/lib/flexmock/argument_matching.rb
@@ -26,14 +26,15 @@ class FlexMock
 
     def all_match_kw?(expected_kw, actual_kw)
       return true if expected_kw.nil?
+      return expected_kw === actual_kw if expected_kw.kind_of? HashMatcher
 
       matched_expected_k = Set.new
       actual_kw.each do |actual_k, actual_v|
-        found_match = expected_kw.any? do |k, v|
+        found_match = expected_kw.find do |k, v|
           match?(k, actual_k) && match?(v, actual_v)
         end
-        matched_expected_k << found_match[0]
         return false unless found_match
+        matched_expected_k << found_match
       end
 
       return false unless matched_expected_k.size == expected_kw.keys.size

--- a/lib/flexmock/composite_expectation.rb
+++ b/lib/flexmock/composite_expectation.rb
@@ -16,9 +16,9 @@ class FlexMock
     end
 
     # Apply the constraint method to all expectations in the composite.
-    def method_missing(sym, *args, &block)
+    def method_missing(sym, *args, **kw, &block)
       @expectations.each do |expectation|
-        expectation.send(sym, *args, &block)
+        expectation.send(sym, *args, **kw, &block)
       end
       self
     end
@@ -38,9 +38,9 @@ class FlexMock
 
     # Start a new method expectation.  The following constraints will be
     # applied to the new expectation.
-    def should_receive(*args, &block)
+    def should_receive(*args, **kw, &block)
       @expectations.first.mock.
-        flexmock_define_expectation(caller, *args, &block)
+        flexmock_define_expectation(caller, *args, **kw, &block)
     end
 
     # Return a string representations

--- a/lib/flexmock/core.rb
+++ b/lib/flexmock/core.rb
@@ -245,8 +245,8 @@ class FlexMock
   #
   # See Expectation for a list of declarators that can be used.
   #
-  def should_receive(*args)
-    flexmock_define_expectation(caller, *args)
+  def should_receive(*args, **kw)
+    flexmock_define_expectation(caller, *args, **kw)
   end
 
   ON_RUBY_20 = (RUBY_VERSION =~ /^2\.0\./)
@@ -302,8 +302,8 @@ class FlexMock
   # to explicitly invoke the method_missing logic.
   def override_existing_method(method_name)
     sclass.class_eval <<-EOS
-      def #{method_name}(*args, &block)
-        method_missing(:#{method_name}, *args, &block)
+      def #{method_name}(*args, **kw, &block)
+        method_missing(:#{method_name}, *args, **kw, &block)
       end
     EOS
   end

--- a/lib/flexmock/core_class_methods.rb
+++ b/lib/flexmock/core_class_methods.rb
@@ -98,18 +98,22 @@ class FlexMock
         end
 
       kw =
-        if kw && !kw.empty?
-          kw = kw.transform_values do |k, v|
+        if kw.kind_of? HashMatcher
+          kw.inspect
+        elsif kw && !kw.empty?
+          kw = kw.transform_values do |v|
             FlexMock.forbid_mocking("<recursive call to mocked method in #inspect>") do
               v.inspect
             end
           end
           kw.map { |k, v| "#{k}: #{v}" }.join(', ')
-        else
-          "**kw"
+        elsif kw.nil?
+          # Don't append **kwargs to signature if ruby version < 3
+          # in order to not break existing code still on ruby2
+          "**kwargs" unless RUBY_VERSION < "3"
         end
 
-      [args, kw].join(", ")
+      [(args unless args.empty?), kw].compact.join(", ")
     end
 
     # Check will assert the block returns true.  If it doesn't, an

--- a/lib/flexmock/expectation.rb
+++ b/lib/flexmock/expectation.rb
@@ -174,11 +174,7 @@ class FlexMock
     # Does the argument list match this expectation's argument
     # specification.
     def match_args(args, kw)
-      expected_args, expected_kw = @signature_validator.keyword_to_positional_arguments(
-        @expected_args, @expected_kw
-      )
-      args, kw = @signature_validator.keyword_to_positional_arguments(args, kw)
-      ArgumentMatching.all_match?(expected_args, expected_kw, args, kw)
+      ArgumentMatching.all_match?(@expected_args, @expected_kw, args, kw)
     end
 
     # Declare that the method should expect the given argument list.

--- a/lib/flexmock/expectation.rb
+++ b/lib/flexmock/expectation.rb
@@ -86,31 +86,31 @@ class FlexMock
       FlexMock.framework_adapter.check(e.message) { false }
     end
 
-    def validate_signature(args)
-      @signature_validator.validate(args)
+    def validate_signature(args, kw)
+      @signature_validator.validate(args, kw)
     rescue SignatureValidator::ValidationFailed => e
       FlexMock.framework_adapter.check(e.message) { false }
     end
 
     # Verify the current call with the given arguments matches the
     # expectations recorded in this object.
-    def verify_call(*args)
+    def verify_call(args, kw)
       validate_eligible
       validate_order
-      validate_signature(args)
+      validate_signature(args, kw)
       @actual_count += 1
       perform_yielding(args)
-      return_value(args)
+      return_value(args, kw)
     end
 
     # Public return value (odd name to avoid accidental use as a
     # constraint).
-    def _return_value(args) # :nodoc:
-      return_value(args)
+    def _return_value(args, kw) # :nodoc:
+      return_value(args, kw)
     end
 
     # Find the return value for this expectation. (private version)
-    def return_value(args)
+    def return_value(args, kw)
       case @return_queue.size
       when 0
         block = lambda { |*a| @return_value }
@@ -119,7 +119,7 @@ class FlexMock
       else
         block = @return_queue.shift
       end
-      block.call(*args)
+      block.call(*args, **kw)
     end
     private :return_value
 
@@ -174,7 +174,11 @@ class FlexMock
     # Does the argument list match this expectation's argument
     # specification.
     def match_args(args, kw)
-      ArgumentMatching.all_match?(@expected_args, @expected_kw, args, kw)
+      expected_args, expected_kw = @signature_validator.keyword_to_positional_arguments(
+        @expected_args, @expected_kw
+      )
+      args, kw = @signature_validator.keyword_to_positional_arguments(args, kw)
+      ArgumentMatching.all_match?(expected_args, expected_kw, args, kw)
     end
 
     # Declare that the method should expect the given argument list.
@@ -208,6 +212,13 @@ class FlexMock
     # arguments of any type.
     def with_any_positional_args
       @expected_args = nil
+      self
+    end
+
+    # Declare that the method should be called with the given
+    # keyword arguments
+    def with_kw_args(kw)
+      @expected_kw = kw
       self
     end
 

--- a/lib/flexmock/expectation_builder.rb
+++ b/lib/flexmock/expectation_builder.rb
@@ -92,7 +92,7 @@ class FlexMock
       names.each do |name|
         exp = mock.flexmock_find_expectation(name)
         if exp
-          next_mock = exp._return_value([])
+          next_mock = exp._return_value([], {})
           check_proper_mock(next_mock, name)
         else
           next_mock = container.flexmock("demeter_#{name}")

--- a/lib/flexmock/expectation_director.rb
+++ b/lib/flexmock/expectation_director.rb
@@ -44,7 +44,7 @@ class FlexMock
                "\nDefined expectations:\n  " +
                @expectations.map(&:description).join("\n  ") }
       ) { !exp.nil? }
-      returned_value = exp.verify_call(*args)
+      returned_value = exp.verify_call(args, kw)
       returned_value
     end
 

--- a/lib/flexmock/expectation_recorder.rb
+++ b/lib/flexmock/expectation_recorder.rb
@@ -23,8 +23,8 @@ class FlexMock
     end
 
     # Save any incoming messages to be played back later.
-    def method_missing(sym, *args, &block)
-      @expectations << [sym, args, block]
+    def method_missing(sym, *args, **kw, &block)
+      @expectations << [sym, args, kw, block]
       self
     end
 
@@ -33,8 +33,8 @@ class FlexMock
     # call).
     def apply(mock)
       obj = mock
-      @expectations.each do |sym, args, block|
-        obj = obj.send(sym, *args, &block)
+      @expectations.each do |sym, args, kw, block|
+        obj = obj.send(sym, *args, **kw, &block)
       end
     end
   end

--- a/lib/flexmock/explicit_needed.rb
+++ b/lib/flexmock/explicit_needed.rb
@@ -31,9 +31,9 @@ class FlexMock
 
     WHITELIST = [:with_signature_matching]
 
-    def method_missing(sym, *args, &block)
+    def method_missing(sym, *args, **kw, &block)
       if explicit? || WHITELIST.include?(sym)
-        @expectation.send(sym, *args, &block)
+        @expectation.send(sym, *args, **kw, &block)
       else
         fail NoMethodError, "Cannot stub methods not defined by the base class\n" +
           "   Method:     #{@method_name}\n" +

--- a/lib/flexmock/test_unit_assert_spy_called.rb
+++ b/lib/flexmock/test_unit_assert_spy_called.rb
@@ -4,12 +4,12 @@ class FlexMock
   module TestUnitAssertions
     include FlexMock::SpyDescribers
 
-    def assert_spy_called(spy, method_name, *args)
-      _assert_spy_called(false, spy, method_name, *args)
+    def assert_spy_called(spy, method_name, *args, **kw)
+      _assert_spy_called(false, spy, method_name, *args, **kw)
     end
 
-    def assert_spy_not_called(spy, method_name, *args)
-      _assert_spy_called(true, spy, method_name, *args)
+    def assert_spy_not_called(spy, method_name, *args, **kw)
+      _assert_spy_called(true, spy, method_name, *args, **kw)
     end
 
     private
@@ -20,7 +20,14 @@ class FlexMock
         options = method_name
         method_name = args.shift
       end
+
+      # Prior to ruby3, kw args would be matched in *args
+      # thus, expecting any args (:_) implied also expecting
+      # any kw args.
+      kw = :_ if args == [:_]
+
       args = nil if args == [:_]
+      kw = nil if kw == :_
       bool = spy.flexmock_received?(method_name, args, kw, options)
       if negative
         bool = !bool

--- a/lib/flexmock/validators.rb
+++ b/lib/flexmock/validators.rb
@@ -208,29 +208,6 @@ class FlexMock
           keyword_splat: #{self.keyword_splat?})"
     end
 
-    # Converts keyword arguments into positional arguments
-    # depending on the method's signature. This is supposed
-    # to replicate ruby < 3 behavior prior to the separation
-    # of keyword and positional arguments.
-    #
-    # It's a no-op if RUBY_VERSION >= 3
-    def keyword_to_positional_arguments(args, kw)
-      return [args, kw] unless RUBY_VERSION < "3"
-
-      args = args.dup
-      should_convert = (!expects_keyword_arguments? && kw && !kw.empty?) ||
-        (args && args.empty? && !requires_keyword_arguments? && !splat? && kw && !kw.empty? && required_arguments > 0) ||
-        (splat? && keyword_splat? && kw && !kw.empty?)
-
-      if should_convert
-        args ||= []
-        args.push kw
-        kw = {}
-      end
-
-      [args, kw]
-    end
-
     # Validates whether the given arguments match the expected signature
     #
     # @param [Array] args
@@ -239,7 +216,6 @@ class FlexMock
       args = args.dup
       kw ||= Hash.new
 
-      args, kw = keyword_to_positional_arguments(args, kw)
       last_is_proc = false
       begin
         if args.last.kind_of?(Proc)

--- a/test/assert_spy_called_test.rb
+++ b/test/assert_spy_called_test.rb
@@ -65,13 +65,31 @@ class AssertSpyCalledTest < Minitest::Test
     spy.foo
     spy.foo(1)
     spy.foo("HI")
+    spy.foo("Hello", "World", 10, { :options => true })
     spy.foo("Hello", "World", 10, :options => true)
-    assert_spy_called spy, {:times => 4}, :foo, :_
+    assert_spy_called spy, {:times => 5}, :foo, :_
+  end
+
+  def test_assert_detects_kw
+    spy.foo(:options => true)
+    times = 1
+
+    if RUBY_VERSION < "3"
+      spy.foo({ :options => true })
+      times += 1
+    end
+
+    assert_spy_called spy, {:times => times}, :foo, options: true
   end
 
   def test_assert_rejects_bad_count_on_any_args
     spy.foo
-    assert_fails(/^expected foo\(\*args\) to be received by <FlexMock:AssertSpyCalledTest::FooBar Mock> twice/i) do
+    signature = if RUBY_VERSION < "3"
+      'foo\(\*args\)'
+    else
+      'foo\(\*args, \*\*kwargs\)'
+    end
+    assert_fails(/^expected #{signature} to be received by <FlexMock:AssertSpyCalledTest::FooBar Mock> twice/i) do
       assert_spy_called spy, {:times => 2}, :foo, :_
     end
   end

--- a/test/expectation_description_test.rb
+++ b/test/expectation_description_test.rb
@@ -33,6 +33,16 @@ class ExpectationDescriptionTest < Minitest::Test
     assert_equal "should_receive(:foo).with(1, \"HI\")", @exp.description
   end
 
+  def test_with_kwargs
+    @exp.with(foo: "bar")
+    assert_equal "should_receive(:foo).with(foo: \"bar\")", @exp.description
+  end
+
+  def test_with_args_and_kwargs
+    @exp.with(1, "two", foo: "bar")
+    assert_equal "should_receive(:foo).with(1, \"two\", foo: \"bar\")", @exp.description
+  end
+
   def test_with_never
     @exp.never
     assert_equal "should_receive(:foo).never", @exp.description

--- a/test/naming_test.rb
+++ b/test/naming_test.rb
@@ -57,6 +57,17 @@ class TestNaming < Minitest::Test
     end
   end
 
+  def test_format_call_properly_adds_splat_operators
+    assert_equal "foo(*args)", FlexMock.format_call(:foo, nil, [])
+    unless RUBY_VERSION < "3"
+      assert_equal "foo(**kwargs)", FlexMock.format_call(:foo, [], nil)
+      assert_equal "foo(*args, **kwargs)", FlexMock.format_call(:foo, nil, nil)
+    else
+      assert_equal "foo()", FlexMock.format_call(:foo, [], nil)
+      assert_equal "foo(*args)", FlexMock.format_call(:foo, nil, nil)
+    end
+  end
+
   def test_mock_can_override_inspect
     FlexMock.use("XYZZY") do |m|
       m.should_receive(:inspect).with_no_args.and_return("MOCK-INSPECT")

--- a/test/partial_mock_test.rb
+++ b/test/partial_mock_test.rb
@@ -634,7 +634,7 @@ class TestStubbing < Minitest::Test
     exception = assert_raises(NameError) do
         obj.mocked_method
     end
-    assert_equal "undefined method `does_not_exist' for #{obj}", exception.message
+    assert_match /undefined method `does_not_exist' for/, exception.message
   end
 
   def test_it_checks_whether_mocks_are_forbidden_before_forwarding_the_call

--- a/test/should_receive_test.rb
+++ b/test/should_receive_test.rb
@@ -421,10 +421,38 @@ class TestFlexMockShoulds < Minitest::Test
     end
   end
 
+  def test_with_kw_matching
+    FlexMock.use('greeter') do |m|
+      m.should_receive(:hi).with(1, a: 2).once
+      m.hi(1, a: 2)
+    end
+
+    FlexMock.use('greeter') do |m|
+      m.should_receive(:hi).with_kw_args(FlexMock.hsh(:a => 1, :b => 2)).once
+      m.hi(:a => 1, :b => 2, :c => 3)
+    end
+  end
+
+  def test_with_kw_not_matching
+    FlexMock.use('greeter') do |m|
+      m.should_receive(:hi).with(1, a: 2)
+      assert_mock_failure(check_failed_error, :deep => true, :line => __LINE__+1) {
+        m.hi(1, a: 2, b: 3)
+      }
+    end
+  end
+
   def test_with_hash_matching
     FlexMock.use('greeter') do |m|
       m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2)).once
-      m.hi(:a => 1, :b => 2, :c => 3)
+      m.hi({:a => 1, :b => 2, :c => 3})
+    end
+
+    if RUBY_VERSION < "3"
+      FlexMock.use('greeter') do |m|
+        m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2)).once
+        m.hi(:a => 1, :b => 2, :c => 3)
+      end
     end
   end
 
@@ -432,8 +460,17 @@ class TestFlexMockShoulds < Minitest::Test
     FlexMock.use('greeter') do |m|
       m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2))
       assert_mock_failure(check_failed_error, :deep => true, :line => __LINE__+1) {
-        m.hi(:a => 1, :b => 4, :c => 3)
+        m.hi({:a => 1, :b => 4, :c => 3})
       }
+    end
+
+    if RUBY_VERSION < "3"
+      FlexMock.use('greeter') do |m|
+        m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2))
+        assert_mock_failure(check_failed_error, :deep => true, :line => __LINE__+1) {
+          m.hi(:a => 1, :b => 4, :c => 3)
+        }
+      end
     end
   end
 
@@ -1231,11 +1268,13 @@ class TestFlexMockShoulds < Minitest::Test
     end
   end
 
-  def test_it_interprets_a_hash_as_last_positional_argument_if_no_keyword_arguments_are_expected
-    FlexMock.use do |mock|
-      mock = flexmock
-      mock.should_receive(:m).with_signature(required_arguments: 2, optional_arguments: 2)
-      mock.m(1, 2, 3, test: 4)
+  if RUBY_VERSION < "3"
+    def test_it_interprets_a_hash_as_last_positional_argument_if_no_keyword_arguments_are_expected
+      FlexMock.use do |mock|
+        mock = flexmock
+        mock.should_receive(:m).with_signature(required_arguments: 2, optional_arguments: 2)
+        mock.m(1, 2, 3, test: 4)
+      end
     end
   end
 
@@ -1350,7 +1389,7 @@ class TestFlexMockShoulds < Minitest::Test
       FlexMock.use do |mock|
         mock.should_receive(:m).
           with_signature(optional_keyword_arguments: [:b], required_arguments: 1)
-        mock.m(Hash.new)
+        mock.m({ :fool => "bar" })
       end
   end
 
@@ -1377,7 +1416,12 @@ class TestFlexMockShoulds < Minitest::Test
       FlexMock.use do |mock|
         mock.should_receive(:m).with_signature(required_arguments: 1, required_keyword_arguments: [:b])
         mock.m(10, b: 10) { }
-        assert_mock_failure(check_failed_error, message: /in mock 'unknown': m\(\*args\) expects at least 1 positional arguments but got only 0/, line: __LINE__+1) do
+        signature = if RUBY_VERSION < "3"
+                      'm\(\*args\)'
+                    else
+                      'm\(\*args, \*\*kwargs\)'
+                    end
+        assert_mock_failure(check_failed_error, message: /in mock 'unknown': #{signature} expects at least 1 positional arguments but got only 0/, line: __LINE__+1) do
           mock.m(b: 10) { }
         end
       end
@@ -1394,10 +1438,14 @@ class TestFlexMockShoulds < Minitest::Test
       FlexMock.use do |mock|
         mock.should_receive(:m).
           with_signature(required_keyword_arguments: [:b], required_arguments: 1)
-        assert_mock_failure(check_failed_error, message: /in mock 'unknown': m\(\*args\) expects at least 1 positional arguments but got only 0/, line: __LINE__+1) do
-          mock.m(Hash.new)
+        signature = 'm\(\*args, \*\*kwargs\)'
+        if RUBY_VERSION < "3"
+          signature = 'm\(\*args\)'
+          assert_mock_failure(check_failed_error, message: /in mock 'unknown': #{signature} expects at least 1 positional arguments but got only 0/, line: __LINE__+1) do
+            mock.m({ :foo => "bar" })
+          end
         end
-        assert_mock_failure(check_failed_error, message: /in mock 'unknown': m\(\*args\) expects at least 1 positional arguments but got only 0/, line: __LINE__+1) do
+        assert_mock_failure(check_failed_error, message: /in mock 'unknown': #{signature} expects at least 1 positional arguments but got only 0/, line: __LINE__+1) do
           mock.m(b: 10)
         end
       end
@@ -1484,4 +1532,3 @@ end
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1')
     require_relative 'should_receive_ruby21plus'
 end
-

--- a/test/should_receive_test.rb
+++ b/test/should_receive_test.rb
@@ -445,14 +445,7 @@ class TestFlexMockShoulds < Minitest::Test
   def test_with_hash_matching
     FlexMock.use('greeter') do |m|
       m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2)).once
-      m.hi({:a => 1, :b => 2, :c => 3})
-    end
-
-    if RUBY_VERSION < "3"
-      FlexMock.use('greeter') do |m|
-        m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2)).once
-        m.hi(:a => 1, :b => 2, :c => 3)
-      end
+      m.hi({:a => 1, :b => 2, :c => 3}, **{})
     end
   end
 
@@ -460,17 +453,8 @@ class TestFlexMockShoulds < Minitest::Test
     FlexMock.use('greeter') do |m|
       m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2))
       assert_mock_failure(check_failed_error, :deep => true, :line => __LINE__+1) {
-        m.hi({:a => 1, :b => 4, :c => 3})
+        m.hi({:a => 1, :b => 4, :c => 3}, **{})
       }
-    end
-
-    if RUBY_VERSION < "3"
-      FlexMock.use('greeter') do |m|
-        m.should_receive(:hi).with(FlexMock.hsh(:a => 1, :b => 2))
-        assert_mock_failure(check_failed_error, :deep => true, :line => __LINE__+1) {
-          m.hi(:a => 1, :b => 4, :c => 3)
-        }
-      end
     end
   end
 
@@ -1268,16 +1252,6 @@ class TestFlexMockShoulds < Minitest::Test
     end
   end
 
-  if RUBY_VERSION < "3"
-    def test_it_interprets_a_hash_as_last_positional_argument_if_no_keyword_arguments_are_expected
-      FlexMock.use do |mock|
-        mock = flexmock
-        mock.should_receive(:m).with_signature(required_arguments: 2, optional_arguments: 2)
-        mock.m(1, 2, 3, test: 4)
-      end
-    end
-  end
-
   def test_with_signature_splat_validates_required_arguments
     FlexMock.use do |mock|
       mock = flexmock
@@ -1383,14 +1357,6 @@ class TestFlexMockShoulds < Minitest::Test
         with_signature(keyword_splat: true, required_arguments: 1)
       mock.m(10, b: 10)
     end
-  end
-
-  def test_signature_validator_understands_that_a_hash_can_be_used_for_both_keywords_and_positional_arguments
-      FlexMock.use do |mock|
-        mock.should_receive(:m).
-          with_signature(optional_keyword_arguments: [:b], required_arguments: 1)
-        mock.m({ :fool => "bar" })
-      end
   end
 
   def test_signature_validator_understands_that_a_proc_last_can_both_be_a_positional_parameter_and_a_block

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,7 +50,11 @@ class FlexMock
     # added.
     def assert_mock_failure(klass, options={}, &block)
       ex = assert_failure(klass, options, &block)
-      file = eval("__FILE__", block.binding)
+      file = if block.binding.respond_to?(:source_location)
+               block.binding.source_location.first
+             else
+               eval("__FILE__", block.binding)
+             end
       assert_matching_line(ex, file, options)
     end
 


### PR DESCRIPTION
Follow-up from: https://github.com/doudou/flexmock/pull/21

This was built on top of https://github.com/doudou/flexmock/tree/keyword_argument_support to make reviewing what was added/changed to the work that was already done easier. Feel free to change the base branch if you prefer to review the whole thing together. Also, please don't forget to change the base branch before merging.

@doudou, as you suggested, support for ruby 2.5 was dropped as it would require the `ruby2_keywords` workaround and handling positional and keyword arguments together in all methods that delegate calls (there are many of them throughout the codebase), which seemed counterproductive.  Also, a new predicate (`Expectation#with_kw_args(kw)`) had to be implemented in order to support "partially" matching keyword arguments (against `HashMatcher`).