### PR TITLE
Compat: Don't use mutable strings for Opal compatibility

### DIFF
--- a/lib/flexmock/expectation.rb
+++ b/lib/flexmock/expectation.rb
@@ -61,7 +61,7 @@ class FlexMock
     # * call count validators
     #
     def description
-      result = "should_receive(#{@sym.inspect})"
+      result = ["should_receive(#{@sym.inspect})"]
       result << ".with(#{FlexMock.format_args(@expected_args)})" if @expected_args
       @count_validators.each do |validator|
         result << validator.describe
@@ -69,7 +69,7 @@ class FlexMock
       if !@signature_validator.null?
         result << @signature_validator.describe
       end
-      result
+      result.join
     end
 
     # Validate that this expectation is eligible for an extra call


### PR DESCRIPTION
I am doing a task of porting a couple of libraries to JavaScript using Opal. One of those libraries is using Flexmock and we want it to run tests on a JavaScript runtime using Opal-RSpec.

Opal is an alternative Ruby implementation, like JRuby, just for JavaScript runtimes. Specifically, it doesn't support mutable strings.

This PR has been sponsored by Ribose Inc. ref: plurimath/plurimath#159