### PR TITLE
fix: pass_thru behavior when the proc is spec-ed via a Proc as last argument

### DIFF
--- a/lib/flexmock/expectation.rb
+++ b/lib/flexmock/expectation.rb
@@ -128,7 +128,7 @@ class FlexMock
 
       if @expected_block
         ret_block.call(*args, &block)
-      elsif block
+      elsif block && @expected_block.nil?
         ret_block.call(*args, block)
       else
         ret_block.call(*args)
@@ -407,6 +407,12 @@ class FlexMock
       block ||= lambda { |value| value }
       and_return { |*args, &orig_block|
         begin
+          if @expected_block.nil? && !orig_block
+            if Proc === args.last
+              orig_block = args.last
+              args = args[0..-2]
+            end
+          end
           block.call(@mock.flexmock_invoke_original(@sym, args, orig_block))
         rescue NoMethodError => e
           if e.name == @sym
@@ -414,7 +420,7 @@ class FlexMock
           else
             raise
           end
-        end 
+        end
       }
     end
 

--- a/test/partial_mock_test.rb
+++ b/test/partial_mock_test.rb
@@ -651,6 +651,20 @@ class TestStubbing < Minitest::Test
     assert_equal block, obj.block
   end
 
+  def test_pass_thru_forwards_a_block_if_there_is_no_explicit_absence
+    obj = Class.new do
+      attr_reader :block
+      def mocked_method(&block)
+        @block = block
+      end
+    end.new
+    flexmock(obj).should_receive(:mocked_method).pass_thru
+
+    block = obj.mocked_method { 42 }
+    assert_kind_of Proc, block
+    assert_equal block, obj.block
+  end
+
   def test_it_checks_whether_mocks_are_forbidden_before_forwarding_the_call
       obj = Class.new
       flexmock(obj).should_receive(:mocked).never


### PR DESCRIPTION
v2.4.1 broke backward compatibility in the following case:

   with(some, arguments, Proc).pass_thru

In that case, the block would be given as positional argument to the original method, instead of being passed as a block.