### PR TITLE
chore: compatibility with ActiveSupport's Object#with

### DIFF
--- a/lib/flexmock/composite_expectation.rb
+++ b/lib/flexmock/composite_expectation.rb
@@ -3,7 +3,8 @@ class FlexMock
   # A composite expectation allows several expectations to be grouped into a
   # single composite and then apply the same constraints to  all expectations
   # in the group.
-  class CompositeExpectation
+  class CompositeExpectation < BasicObject
+    attr_reader :expectations
 
     # Initialize the composite expectation.
     def initialize

--- a/lib/flexmock/expectation_recorder.rb
+++ b/lib/flexmock/expectation_recorder.rb
@@ -34,7 +34,7 @@ class FlexMock
     def apply(mock)
       obj = mock
       @expectations.each do |sym, args, block|
-        obj = obj.send(sym, *args, &block)
+        obj = obj.__send__(sym, *args, &block)
       end
     end
   end

--- a/test/should_receive_ruby21plus.rb
+++ b/test/should_receive_ruby21plus.rb
@@ -5,7 +5,7 @@ class TestFlexMockShoulds < Minitest::Test
     k = Class.new { def m(req_a:, req_b:, opt_c: 10, **kw_splat); end }
     FlexMock.use do |mock|
       e = mock.should_receive(:test).with_signature_matching(k.instance_method(:m))
-      e = e.instance_variable_get(:@expectations).first
+      e = e.expectations.first
       validator = e.instance_variable_get(:@signature_validator)
       assert_equal 0, validator.required_arguments
       assert_equal 0, validator.optional_arguments

--- a/test/should_receive_test.rb
+++ b/test/should_receive_test.rb
@@ -1530,7 +1530,7 @@ class TestFlexMockShoulds < Minitest::Test
     k = Class.new { def m(req_a, req_b, opt_c = 10); end }
     FlexMock.use do |mock|
       e = mock.should_receive(:m).with_signature_matching(k.instance_method(:m))
-      e = e.instance_variable_get(:@expectations).first
+      e = e.expectations.first
       validator = e.instance_variable_get(:@signature_validator)
       assert_equal 2, validator.required_arguments
       assert_equal 1, validator.optional_arguments
@@ -1545,7 +1545,7 @@ class TestFlexMockShoulds < Minitest::Test
     k = Class.new { def m(req_a, req_b, opt_c = 10, *splat); end }
     FlexMock.use do |mock|
       e = mock.should_receive(:m).with_signature_matching(k.instance_method(:m))
-      e = e.instance_variable_get(:@expectations).first
+      e = e.expectations.first
       validator = e.instance_variable_get(:@signature_validator)
       assert_equal 2, validator.required_arguments
       assert_equal 1, validator.optional_arguments


### PR DESCRIPTION
Since activesupport defines it on object, it supersedes the method_missing mechanism. Make CompositeExpectation a subclass of BasicObject to work around