### PR TITLE
fix ruby3.4 formatting change

### DIFF
--- a/lib/flexmock/spy_describers.rb
+++ b/lib/flexmock/spy_describers.rb
@@ -18,7 +18,7 @@ class FlexMock
       end
 
       def describe_spy(spy, sym, args, kw, options, not_clause="")
-        result = "expected "
+        result = +"expected "
         result << FlexMock.format_call(sym, args, kw)
         result << " to#{not_clause} be received by " << spy.inspect
         result << times_description(options[:times])
@@ -29,7 +29,7 @@ class FlexMock
       end
 
       def describe_calls(spy)
-        result = ''
+        result = +''
         if spy.flexmock_calls.empty?
           result << "No messages have been received\n"
         else

--- a/test/container_methods_test.rb
+++ b/test/container_methods_test.rb
@@ -113,7 +113,7 @@ class TestFlexmockContainerMethods < Minitest::Test
   end
 
   def test_stubbing_a_string
-    s = "hello"
+    s = +"hello"
     flexmock(:base, s, :length => 2)
     assert_equal 2, s.length
   end

--- a/test/partial_mock_test.rb
+++ b/test/partial_mock_test.rb
@@ -634,7 +634,7 @@ class TestStubbing < Minitest::Test
     exception = assert_raises(NameError) do
         obj.mocked_method
     end
-    assert_match(/undefined method `does_not_exist' for/, exception.message)
+    assert_match(/undefined method [`']does_not_exist' for/, exception.message)
   end
 
   def test_it_checks_whether_mocks_are_forbidden_before_forwarding_the_call

--- a/test/rspec_integration/integration_spec.rb
+++ b/test/rspec_integration/integration_spec.rb
@@ -32,7 +32,7 @@ describe "FlexMock in a RSpec example" do
   end
 
   specify "should be able to create a stub" do
-    s = "Hello World"
+    s = +"Hello World"
     flexmock(:base, s).should_receive(:downcase).with().once.and_return("hello WORLD")
 
     expect(s.downcase).to eq("hello WORLD")


### PR DESCRIPTION
ruby 3.4 changes formatting for some backtrace messages. Support this using regex.

Closes #37 .