### PR TITLE
fix: Use Minitest assert_raises correctly and handle error message

### DIFF
--- a/test/based_partials_test.rb
+++ b/test/based_partials_test.rb
@@ -46,9 +46,10 @@ class BasedPartialsTest < Minitest::Test
 
   def test_based_partials_disallow_stubbing_undefined_methods
     dog = Dog.new
-    assert_raises(NoMethodError, /cannot stub.*wag.*explicitly/) do
+    ex = assert_raises(NoMethodError) do
       flexmock(dog).should_receive(:wag => :mock_value)
     end
+    assert_match(/Cannot stub.*wag.*explicitly/m, ex.message)
   end
 
   def test_based_partials_allow_explicitly_stubbing_undefined_methods

--- a/test/partial_mock_test.rb
+++ b/test/partial_mock_test.rb
@@ -457,9 +457,10 @@ class TestStubbing < Minitest::Test
   def test_partial_mocks_disallow_stubbing_undefined_methods_when_using_on
     dog = Dog.new
     flexmock(dog, :on, Dog)
-    assert_raises(NoMethodError, /meow.*explicitly/) do
+    ex = assert_raises(NoMethodError) do
       dog.should_receive(:meow).and_return(:something)
     end
+    assert_match(/meow.*explicitly/m, ex.message)
   end
 
   def test_partial_mocks_properly_detect_methods_defined_through_a_class_hierarchy
@@ -497,9 +498,10 @@ class TestStubbing < Minitest::Test
     def test_based_partial_mocks_require_explicitly_on_a_non_existing_method_of_a_class_singleton
       dog = Class.new
       FlexMock.partials_are_based = true
-      assert_raises(NoMethodError, /bark.*explicitly/) do
+      ex = assert_raises(NoMethodError) do
         flexmock(dog).should_receive(:bark).and_return(:grrr)
       end
+      assert_match(/bark.*explicitly/m, ex.message)
     ensure
       FlexMock.partials_are_based = false
     end
@@ -511,9 +513,10 @@ class TestStubbing < Minitest::Test
       FlexMock.partials_are_based = true
       flexmock(dog).should_receive(:bark).explicitly
       flexmock(chiwawa)
-      assert_raises(NoMethodError, /bark.*explicitly/) do
+      ex = assert_raises(NoMethodError) do
         chiwawa.should_receive(:bark).and_return(:grrr)
       end
+      assert_match(/bark.*explicitly/m, ex.message)
     ensure
       FlexMock.partials_are_based = false
     end


### PR DESCRIPTION
Actually
https://github.com/minitest/minitest/blob/v6.0.5/lib/minitest/assertions.rb#L390 says that `assert_raises` can take an optional "message" (i.e. string) to help explain failures, so not regex or so to test if assertion message matches it.

Up to Minitest 6.0.4, when passing regex for `assert_raises` it was simply ignored, ref:

https://github.com/minitest/minitest/issues/1068
https://bugs.ruby-lang.org/issues/22007

Now Minitest 6.0.5 explicitly refuses this usage as: https://github.com/minitest/minitest/commit/6790f86f894637768a1f64cfe50959d2029b65ed

Closes #39 .